### PR TITLE
Fix na validação dos inputs

### DIFF
--- a/src/containers/Login/Login.js
+++ b/src/containers/Login/Login.js
@@ -70,9 +70,11 @@ export class Login extends Component {
                             type={this.state.showPassword ? 'text' : 'password'}
                             label="Senha"
                             placeholder="Mínimo 6 caracteres"
+                            minlenght="6"
                             value={password}
                             required={true}
                             InputProps={{
+                                minLength: 6,
                                 endAdornment: (
                                     <InputAdornment position="end">
                                         <IconButton
@@ -89,6 +91,7 @@ export class Login extends Component {
                             variant="contained"
                             color="primary"
                             type='submit'
+                            disabled={!this.state.password}
                         > Entrar
                         </StyledBtn>
 

--- a/src/containers/SignUp/signup.js
+++ b/src/containers/SignUp/signup.js
@@ -80,18 +80,24 @@ export class SignUp extends Component {
                             placeholder="email@email.com"
                             value={email}
                             required={true}
-                            inputProps={{ pattern: "[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" }}
+                            inputProps={{ 
+                                pattern: "[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+                            }}
                         />
                         <StyledTextField
                             onChange={this.handleFieldChange}
                             variant="outlined"
                             name="cpf"
-                            type="number"
+                            type="text"
                             label="CPF"
                             placeholder="xxx.xxx.xxx.xx"
                             value={cpf}
+                            maxLenght="11"
                             required={true}
-                            inputProps={{ pattern: "[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" }}
+                            inputProps={{ 
+                                pattern: "/^\d{3}\.\d{3}\.\d{3}\-\d{2}$/",
+                                maxLength: 11
+                             }}
                         />
                         <StyledTextField
                             onChange={this.handleFieldChange}
@@ -103,6 +109,7 @@ export class SignUp extends Component {
                             value={password}
                             required={true}
                             InputProps={{
+                                minLength: 6,
                                 endAdornment: (
                                     <InputAdornment position="end">
                                         <IconButton
@@ -125,6 +132,7 @@ export class SignUp extends Component {
                             value={password2}
                             required={true}
                             InputProps={{
+                                minLength: 6,
                                 endAdornment: (
                                     <InputAdornment position="end">
                                         <IconButton


### PR DESCRIPTION
### O que funciona
- input do CPF só permite no máximo 11 caracteres
- input do CPF com regex pra validar CPF
- botão do login só fica disponível após usuário digitar a senha
- input de senhas com validação pra aceitar mínimo de 6 caracteres


